### PR TITLE
Keep compatibility with PHP 8.0

### DIFF
--- a/tests/BanTest.php
+++ b/tests/BanTest.php
@@ -18,6 +18,7 @@ final class BanTest extends TestCase
     protected function setUp(): void
     {
         $class = new ReflectionClass(Ban::class);
+        $class->setAccessible(true);
         $cache = $class->getStaticPropertyValue('cache');
         $clean_cache = [];
 


### PR DESCRIPTION
Keep compatibility with PHP 8.0; however, since PHP 8.1, private and protected properties can now be accessed by ReflectionProperty::getValue() right away. Previously, they needed to be made accessible by calling ReflectionProperty::setAccessible();